### PR TITLE
Added support for quaideslivres.fr (french bookstore)

### DIFF
--- a/src/helpers/__snapshots__/stores.test.ts.snap
+++ b/src/helpers/__snapshots__/stores.test.ts.snap
@@ -253,6 +253,15 @@ Array [
       "stripbooks",
       "books",
     ],
+    "title": "quaideslivres.fr",
+    "url": "https://quaideslivres.fr/catalogsearch/advanced/result/?isbn=%1$s",
+  },
+  Object {
+    "categories": Array [
+      "english-books",
+      "stripbooks",
+      "books",
+    ],
     "title": "recyclivre.com",
     "url": "https://www.recyclivre.com/shop/recherche?orderby=price&orderway=asc&s=%1$s&submit_search=",
   },
@@ -804,6 +813,15 @@ Array [
       "stripbooks",
       "books",
     ],
+    "title": "quaideslivres.fr",
+    "url": "https://quaideslivres.fr/catalogsearch/advanced/result/?isbn=%1$s",
+  },
+  Object {
+    "categories": Array [
+      "english-books",
+      "stripbooks",
+      "books",
+    ],
     "title": "recyclivre.com",
     "url": "https://www.recyclivre.com/shop/recherche?orderby=price&orderway=asc&s=%1$s&submit_search=",
   },
@@ -1250,6 +1268,15 @@ Array [
     ],
     "title": "leslibraires.fr",
     "url": "https://www.leslibraires.fr/livre/%1$s",
+  },
+  Object {
+    "categories": Array [
+      "english-books",
+      "stripbooks",
+      "books",
+    ],
+    "title": "quaideslivres.fr",
+    "url": "https://quaideslivres.fr/catalogsearch/advanced/result/?isbn=%1$s",
   },
   Object {
     "categories": Array [

--- a/src/helpers/stores.test.ts
+++ b/src/helpers/stores.test.ts
@@ -18,7 +18,7 @@ test('getCountryStores returns French stores', () => {
   const stores = getCountryStores('www.amazon.fr')
 
   expect(stores).toMatchSnapshot()
-  expect(stores.length).toBe(45)
+  expect(stores.length).toBe(46)
   checkObjectKeys(stores)
 })
 
@@ -74,14 +74,14 @@ test('getCountryStores with inexsting tld returns default stores', () => {
   const stores = getCountryStores('www.amazon.xyz')
 
   expect(stores).toMatchSnapshot()
-  expect(stores.length).toBe(45)
+  expect(stores.length).toBe(46)
   checkObjectKeys(stores)
 })
 test('getCountryStores with empty host returns default stores', () => {
   const stores = getCountryStores('')
 
   expect(stores).toMatchSnapshot()
-  expect(stores.length).toBe(45)
+  expect(stores.length).toBe(46)
   checkObjectKeys(stores)
 })
 

--- a/src/helpers/stores/fr.ts
+++ b/src/helpers/stores/fr.ts
@@ -148,6 +148,11 @@ export const stores: Store[] = [
     categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS],
   },
   {
+    title: 'quaideslivres.fr',
+    url: 'https://quaideslivres.fr/catalogsearch/advanced/result/?isbn=%1$s',
+    categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS],
+  },
+  {
     title: 'recyclivre.com',
     url: 'https://www.recyclivre.com/shop/recherche?orderby=price&orderway=asc&s=%1$s&submit_search=',
     categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS],


### PR DESCRIPTION
C'est mon site, on vend des livres d'occasion. J'espère que ma PR n'est pas déplacée, mais je pense que nous rentrons parfaitement dans le cadre des objectifs de cette extension.

Super idée en tous cas, félicitations !

Au cas où tu n'es pas au courant, France Inter a fait ta promo: https://www.franceinter.fr/culture/acheter-des-livres-pendant-le-confinement-voici-12-alternatives-a-amazon
C'est grâce à leur article que j'ai découvert ton code.