### PR TITLE
Add alternatives for German Amazon

### DIFF
--- a/src/helpers/stores/de.ts
+++ b/src/helpers/stores/de.ts
@@ -42,4 +42,29 @@ export const stores: Store[] = [
     url: 'https://www.hugendubel.de/de/quickSearch?searchString=%1$s',
     categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS, Category.DIGITAL_TEXT, Category.DVD, Category.CLASSICAL],
   },
+  {
+    title: 'Mediamarkt',
+    url: 'https://www.mediamarkt.de/de/search.html?query=%1$s',
+    categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS, Category.DIGITAL_TEXT, Category.DVD, Category.CLASSICAL, Category.ELECTRONICS, Category.COMPUTERS, Category.APPLIANCES],
+  },
+  {
+    title: 'Saturn',
+    url: 'https://www.saturn.de/de/search.html?query=%1$s',
+    categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS, Category.DIGITAL_TEXT, Category.DVD, Category.CLASSICAL, Category.ELECTRONICS, Category.COMPUTERS, Category.APPLIANCES],
+  },
+  {
+    title: 'Notebooksbilliger',
+    url: 'https://www.notebooksbilliger.de/produkte/%1$s',
+    categories: [Category.ELECTRONICS, Category.COMPUTERS],
+  },
+  {
+    title: 'Cyberport',
+    url: 'https://www.cyberport.de/tools/search-results.html?q=%1$s',
+    categories: [Category.ELECTRONICS, Category.COMPUTERS],
+  },
+  {
+    title: 'Expert',
+    url: 'https://www.expert.de/suche?q=%1$s',
+    categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS, Category.DIGITAL_TEXT, Category.DVD, Category.CLASSICAL, Category.ELECTRONICS, Category.COMPUTERS, Category.APPLIANCES],
+  },
 ]

--- a/src/helpers/stores/de.ts
+++ b/src/helpers/stores/de.ts
@@ -27,4 +27,19 @@ export const stores: Store[] = [
     url: 'http://www.feedbooks.com/search?lang=de&query=%1$s',
     categories: [Category.DIGITAL_TEXT],
   },
+  {
+    title: 'Thalia',
+    url: 'https://www.thalia.de/suche?sq=%1$s',
+    categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS, Category.DIGITAL_TEXT, Category.DVD, Category.VIDEOGAMES, Category.CLASSICAL],
+  },
+  {
+    title: 'Weltbild',
+    url: 'https://www.weltbild.de/suche/%1$s',
+    categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS, Category.DIGITAL_TEXT, Category.DVD, Category.CLASSICAL],
+  },
+  {
+    title: 'Hugendubel',
+    url: 'https://www.hugendubel.de/de/quickSearch?searchString=%1$s',
+    categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS, Category.DIGITAL_TEXT, Category.DVD, Category.CLASSICAL],
+  },
 ]


### PR DESCRIPTION
To have a more complete experience I'm trying to add the most popular German store alternatives, some of which are also brick-and-mortar stores. Currently books and electronics are added, I'll have to double check the categories and will mark this as final if I think the most important ones are here. And when I have tested all integrations (have to check how I do that first...).

Does [stores.ts](https://github.com/amazon-alternatives/extension/blob/main/src/helpers/stores.ts#L53) contain the authoritative list of categories or are there more Amazon categories currently not used? I'm for example missing audiobooks from that list.

What kind of other criteria have to be met for a store to be added to the list? 

Is there a limit on how many stores per category are considered useful?