### PR TITLE
Add Ethical Book Search to Canadian, UK and US stores

### DIFF
--- a/src/helpers/__snapshots__/stores.test.ts.snap
+++ b/src/helpers/__snapshots__/stores.test.ts.snap
@@ -34,6 +34,16 @@ Array [
     "title": "feedbooks.com",
     "url": "http://www.feedbooks.com/search?lang=en&query=%1$s",
   },
+  Object {
+    "categories": Array [
+      "english-books",
+      "stripbooks",
+      "books",
+      "digital-text",
+    ],
+    "title": "ethicalbooksearch.com",
+    "url": "https://www.ethicalbooksearch.com/us/books/m/is:%1$s/?source=amazon-alternatives-extension",
+  },
 ]
 `;
 
@@ -61,6 +71,16 @@ Array [
     ],
     "title": "feedbooks.com",
     "url": "http://www.feedbooks.com/search?lang=en&query=%1$s",
+  },
+  Object {
+    "categories": Array [
+      "english-books",
+      "stripbooks",
+      "books",
+      "digital-text",
+    ],
+    "title": "ethicalbooksearch.com",
+    "url": "https://www.ethicalbooksearch.com/ca/books/m/is:%1$s/?source=amazon-alternatives-extension",
   },
 ]
 `;
@@ -675,6 +695,16 @@ Array [
     ],
     "title": "feedbooks.com",
     "url": "http://www.feedbooks.com/search?lang=en&query=%1$s",
+  },
+  Object {
+    "categories": Array [
+      "english-books",
+      "stripbooks",
+      "books",
+      "digital-text",
+    ],
+    "title": "ethicalbooksearch.com",
+    "url": "https://www.ethicalbooksearch.com/uk/books/m/is:%1$s/?source=amazon-alternatives-extension",
   },
 ]
 `;

--- a/src/helpers/stores.test.ts
+++ b/src/helpers/stores.test.ts
@@ -26,7 +26,7 @@ test('getCountryStores returns American stores', () => {
   const stores = getCountryStores('www.amazon.com')
 
   expect(stores).toMatchSnapshot()
-  expect(stores.length).toBe(4)
+  expect(stores.length).toBe(5)
   checkObjectKeys(stores)
 })
 
@@ -34,7 +34,7 @@ test('getCountryStores returns Canadian stores', () => {
   const stores = getCountryStores('www.amazon.ca')
 
   expect(stores).toMatchSnapshot()
-  expect(stores.length).toBe(3)
+  expect(stores.length).toBe(4)
   checkObjectKeys(stores)
 })
 
@@ -42,7 +42,7 @@ test('getCountryStores returns UK stores', () => {
   const stores = getCountryStores('www.amazon.co.uk')
 
   expect(stores).toMatchSnapshot()
-  expect(stores.length).toBe(8)
+  expect(stores.length).toBe(9)
   checkObjectKeys(stores)
 })
 

--- a/src/helpers/stores/ca.ts
+++ b/src/helpers/stores/ca.ts
@@ -16,4 +16,9 @@ export const stores: Store[] = [
     url: 'http://www.feedbooks.com/search?lang=en&query=%1$s',
     categories: [Category.DIGITAL_TEXT],
   },
+  {
+    title: 'ethicalbooksearch.com',
+    url: 'https://www.ethicalbooksearch.com/ca/books/m/is:%1$s/?source=amazon-alternatives-extension',
+    categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS, Category.DIGITAL_TEXT],
+  },
 ]

--- a/src/helpers/stores/com.ts
+++ b/src/helpers/stores/com.ts
@@ -21,4 +21,9 @@ export const stores: Store[] = [
     url: 'http://www.feedbooks.com/search?lang=en&query=%1$s',
     categories: [Category.DIGITAL_TEXT],
   },
+  {
+    title: 'ethicalbooksearch.com',
+    url: 'https://www.ethicalbooksearch.com/us/books/m/is:%1$s/?source=amazon-alternatives-extension',
+    categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS, Category.DIGITAL_TEXT],
+  },
 ]

--- a/src/helpers/stores/uk.ts
+++ b/src/helpers/stores/uk.ts
@@ -48,4 +48,9 @@ export const stores: Store[] = [
     url: 'http://www.feedbooks.com/search?lang=en&query=%1$s',
     categories: [Category.DIGITAL_TEXT],
   },
+  {
+    title: 'ethicalbooksearch.com',
+    url: 'https://www.ethicalbooksearch.com/uk/books/m/is:%1$s/?source=amazon-alternatives-extension',
+    categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS, Category.DIGITAL_TEXT],
+  },
 ]


### PR DESCRIPTION
Ethical Book Search provides a price comparisons between a range of book sellers who sell both ebooks, audiobooks and print who are far more responsible than Amazon.

Adding this to the list of book sellers makes it easier for users of this extension to compare a range of alternatives to amazon.