### PR TITLE
Update Ethical Book Search links

### DIFF
--- a/src/helpers/__snapshots__/stores.test.ts.snap
+++ b/src/helpers/__snapshots__/stores.test.ts.snap
@@ -42,7 +42,7 @@ Array [
       "digital-text",
     ],
     "title": "ethicalbooksearch.com",
-    "url": "https://www.ethicalbooksearch.com/us/books/m/is:%1$s/?source=amazon-alternatives-extension",
+    "url": "https://www.ethicalbooksearch.com/us?query=%1$s/?source=amazon-alternatives-extension",
   },
 ]
 `;
@@ -80,7 +80,7 @@ Array [
       "digital-text",
     ],
     "title": "ethicalbooksearch.com",
-    "url": "https://www.ethicalbooksearch.com/ca/books/m/is:%1$s/?source=amazon-alternatives-extension",
+    "url": "https://www.ethicalbooksearch.com/ca?query=%1$s/?source=amazon-alternatives-extension",
   },
 ]
 `;
@@ -704,7 +704,7 @@ Array [
       "digital-text",
     ],
     "title": "ethicalbooksearch.com",
-    "url": "https://www.ethicalbooksearch.com/uk/books/m/is:%1$s/?source=amazon-alternatives-extension",
+    "url": "https://www.ethicalbooksearch.com/uk?query=%1$s/?source=amazon-alternatives-extension",
   },
 ]
 `;

--- a/src/helpers/stores/ca.ts
+++ b/src/helpers/stores/ca.ts
@@ -18,7 +18,7 @@ export const stores: Store[] = [
   },
   {
     title: 'ethicalbooksearch.com',
-    url: 'https://www.ethicalbooksearch.com/ca/books/m/is:%1$s/?source=amazon-alternatives-extension',
+    url: 'https://www.ethicalbooksearch.com/ca?query=%1$s/?source=amazon-alternatives-extension',
     categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS, Category.DIGITAL_TEXT],
   },
 ]

--- a/src/helpers/stores/com.ts
+++ b/src/helpers/stores/com.ts
@@ -23,7 +23,7 @@ export const stores: Store[] = [
   },
   {
     title: 'ethicalbooksearch.com',
-    url: 'https://www.ethicalbooksearch.com/us/books/m/is:%1$s/?source=amazon-alternatives-extension',
+    url: 'https://www.ethicalbooksearch.com/us?query=%1$s/?source=amazon-alternatives-extension',
     categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS, Category.DIGITAL_TEXT],
   },
 ]

--- a/src/helpers/stores/uk.ts
+++ b/src/helpers/stores/uk.ts
@@ -50,7 +50,7 @@ export const stores: Store[] = [
   },
   {
     title: 'ethicalbooksearch.com',
-    url: 'https://www.ethicalbooksearch.com/uk/books/m/is:%1$s/?source=amazon-alternatives-extension',
+    url: 'https://www.ethicalbooksearch.com/uk?query=%1$s/?source=amazon-alternatives-extension',
     categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS, Category.DIGITAL_TEXT],
   },
 ]


### PR DESCRIPTION
To link to the search. This will be a better experience for users because if the term is an ISBN number it will redirect to a buying options for just that edition and if it is anything else, for example a title, then it will present the most relevant results.