### PR TITLE
Fix worldofbooks.com book search URL, add DVD url

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -51,7 +51,7 @@ const getSearch = (category: Category): string => {
     return (
       isbnNode.textContent
         ?.split(':')[1]
-        .replace(/(\n|\s|-)/g, '')
+        .replace(/[^0-9]/gm, '')
         .trim() || ''
     )
   }

--- a/src/helpers/stores/uk.ts
+++ b/src/helpers/stores/uk.ts
@@ -15,13 +15,13 @@ export const stores: Store[] = [
   },
   {
     title: 'worldofbooks.com',
-    url: 'https://www.worldofbooks.com/en-gb/books/xxx/xxx/%1$s',
+    url: 'https://www.worldofbooks.com/en-gb/category/all?pt=book&search=%1$s',
     categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS],
   },
   {
-    title: 'wordery.com',
-    url: 'https://wordery.com/search?term=%1$s',
-    categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS],
+    title: 'worldofbooks.com',
+    url: 'https://www.worldofbooks.com/en-gb/category/all?pt=dvd&search=%1$s',
+    categories: [Category.DVD],
   },
   {
     title: 'booksetc.co.uk',

--- a/src/helpers/stores/uk.ts
+++ b/src/helpers/stores/uk.ts
@@ -24,6 +24,11 @@ export const stores: Store[] = [
     categories: [Category.DVD],
   },
   {
+    title: 'wordery.com',
+    url: 'https://wordery.com/search?term=%1$s',
+    categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS],
+  },
+  {
     title: 'booksetc.co.uk',
     url: 'https://www.booksetc.co.uk/books/search?q=%1$s',
     categories: [Category.ENGLISH_BOOKS, Category.STRIPBOOKS, Category.BOOKS],


### PR DESCRIPTION
The URLs suggested for worldofbooks.com seem broken, based on a few clicks. Here's a proposed alternative, which should propose links for the user like:

- Book: https://www.worldofbooks.com/en-gb/category/all?search=Brain&pt=book
- DVD: https://www.worldofbooks.com/en-gb/category/all?search=Beverly%20Hill%20Ninjas&pt=dvd