### PR TITLE
Fix buchkatalog.at

### DIFF
--- a/src/helpers/stores/de.ts
+++ b/src/helpers/stores/de.ts
@@ -108,7 +108,7 @@ export const stores: Store[] = [
   {
     title: 'Thomann',
     url: 'https://www.thomann.de/intl/search_dir.html?sw=%1$s',
-    categories: [Category.MI, Category.CLASSICAL, Category.ELECTRONICS, Category.COMPUTERS, Category.APPLIANCES],
+    categories: [Category.CLASSICAL, Category.COMPUTERS, Category.ELECTRONICS, Category.MI],
   },
   {
     title: 'Notebooksbilliger',

--- a/src/helpers/stores/de.ts
+++ b/src/helpers/stores/de.ts
@@ -13,8 +13,7 @@ export const stores: Store[] = [
   },
   {
     title: 'buchkatalog.at',
-    url:
-      'https://www.buchkatalog.at/webapp/wcs/stores/servlet/KNVAdvancedSearchResult?storeId=270205&catalogId=4099276460822233275&langId=-3&fromAdvanceSearch=AdvanceSearch&pageType=HU&stock=&iehack=%E2%98%A0&offer=&avail=&media=All+Media&title=&keyword=&author1=&author=&actor1=&actor=&topic=&publisher1=&publisher=&movie_category=All+Categories&articleno=%1$s&lang=&lang1=deutsch&movie_subtitle=&covertype=all&range_price=from-to&price_from=&price_to=&range_age=from-to&age_from=&age_to=&range_age1=from-to&age1_from=&age1_to=&range_age2=from-to&age2_from=&age2_to=&range_issuedate=from-to&issuedate_from=&issuedate_to=&issue1=&issue=&nott=',
+    url: 'https://shop.buchkatalog.at/servlet/SearchDisplay?catalogId=10002&searchTerm=%1$s',
     categories: [Category.BOOKS_INTL_DE, Category.BOOKS_CATALOG],
   },
   {
@@ -109,13 +108,7 @@ export const stores: Store[] = [
   {
     title: 'Thomann',
     url: 'https://www.thomann.de/intl/search_dir.html?sw=%1$s',
-    categories: [
-      Category.MI,
-      Category.CLASSICAL,
-      Category.ELECTRONICS,
-      Category.COMPUTERS,
-      Category.APPLIANCES,
-    ],
+    categories: [Category.MI, Category.CLASSICAL, Category.ELECTRONICS, Category.COMPUTERS, Category.APPLIANCES],
   },
   {
     title: 'Notebooksbilliger',


### PR DESCRIPTION
The old URL returned errors for me, for example with [The Midnight Library](https://www.amazon.de/Midnight-Library-Matt-Haig/dp/1786892731). The new URL is only the essential parameters of a search and was tested with `yarn build` and loading the addon in Firefox.